### PR TITLE
compability with enrol_wallet

### DIFF
--- a/manage.php
+++ b/manage.php
@@ -106,15 +106,21 @@ if (!$bank_entries) {
         if ($filter != '' && ($bankentrykey != $filter)) {
             continue;
         }
+        
+        // Always use the data from the bank entry
+        $currency = $bank_entry->currency;
+        $amount = $bank_entry->totalamount;
+
+        // Try to get additional information if available
         try {
             $config = (object) helper::get_gateway_configuration($bank_entry->component, $bank_entry->paymentarea, $bank_entry->itemid, 'bank');
             $payable = helper::get_payable($bank_entry->component, $bank_entry->paymentarea, $bank_entry->itemid);
+            // If successful, update currency and apply surcharge
             $currency = $payable->get_currency();
-            $amount = helper::get_rounded_cost($payable->get_amount(), $currency, helper::get_gateway_surcharge('paypal'));
+            $amount = helper::get_rounded_cost($amount, $currency, helper::get_gateway_surcharge('paypal'));
         } catch (\Exception $e) {
-            // If we can't get the configuration or payable, use the data from the bank entry
-            $currency = $bank_entry->currency;
-            $amount = $bank_entry->totalamount;
+            // If we can't get the configuration or payable, just use the bank entry data (already set)
+            debugging('Error getting payment configuration: ' . $e->getMessage(), DEBUG_DEVELOPER);
         }
 
         $customer = $DB->get_record('user', array('id' => $bank_entry->userid));
@@ -222,7 +228,7 @@ function sendmail() {
                     <input type="hidden" name="action" value="sendmail">
                     <input type="hidden" name="confirm" value="1">
                     <input type="hidden" name="ids" id="ids" value="">
-        
+
                     <div class="form-group">
                         <label for="subject"><?php echo get_string('subject'); ?></label>
                         <input type="text" class="form-control" id="subject" name="subject" required>

--- a/pay.php
+++ b/pay.php
@@ -151,6 +151,7 @@ if ($confirm == 0 && !bank_helper::has_openbankentry($itemid, $USER->id)) {
                     {
                         $tempdir = make_request_directory();
                         $fullpath = $tempdir . '/' . $name;
+                        $override = false; // Define $override variable
                         $success = $at_form->save_file('userfile', $fullpath, $override);
                         $fileinfo = array(
                             'contextid' => context_system::instance()->id,
@@ -160,7 +161,7 @@ if ($confirm == 0 && !bank_helper::has_openbankentry($itemid, $USER->id)) {
                             'filename' =>  $name,
                             'itemid' => $bank_entry->id,
                             'userid' => $USER->id,
-                            'author' => fullname($USER->true)
+                            'author' => fullname($USER)
                         );
                         $fs->create_file_from_pathname($fileinfo, $fullpath);
                         bank_helper::check_hasfiles($bank_entry->id);
@@ -171,10 +172,10 @@ if ($confirm == 0 && !bank_helper::has_openbankentry($itemid, $USER->id)) {
                             $supportuser = core_user::get_support_user();
                             $subject = get_string('email_notifications_subject_attachments', 'paygw_bank');
                             $contentmessage = new stdClass;
-                            $contentmessage->code = $record->code;
-                            $contentmessage->concept = $record->description;
+                            $contentmessage->code = $bank_entry->code;
+                            $contentmessage->concept = $bank_entry->description;
                             $contentmessage->useremail=$USER->email;
-                            $contentmessage->userfullname=fullname($USER,true);
+                            $contentmessage->userfullname=fullname($USER);
                             $mailcontent = get_string('email_notifications_new_attachments', 'paygw_bank', $contentmessage);
                             $emailuser = new stdClass();
                             $emailuser->email = $emailaddress;


### PR DESCRIPTION
This PR adds compability to [fmido88/moodle-enrol_wallet](https://github.com/fmido88/moodle-enrol_wallet) plugin.

The bank payment gateway was relying on records in the enrol_wallet_items table to display and manage pending payments. When these temporary records were deleted, it caused errors in the frontend manage.php interface.

**Errors I had:**

**1:**
```
2024/09/21 14:07:31 [error] 2300968#2300968: *642275 FastCGI sent in stderr: "PHP message: PHP Warning:  Undefined variable $override in /my_server/public_html/payment/gateway/bank/pay.php on line 154
PHP message: PHP Warning:  Undefined property: stdClass::$true in /my_server/public_html/payment/gateway/bank/pay.php on line 163
PHP message: PHP Warning:  Undefined variable $record in /my_server/public_html/payment/gateway/bank/pay.php on line 174
PHP message: PHP Warning:  Attempt to read property "code" on null in /my_server/public_html/payment/gateway/bank/pay.php on line 174
PHP message: PHP Warning:  Undefined variable $record in /my_server/public_html/payment/gateway/bank/pay.php on line 175
PHP message: PHP Warning:  Attempt to read property "description" on null in /my_server/public_html/payment/gateway/bank/pay.php on line 175" 
while reading upstream, client: 93.180.98.98, server: my_server, request: "POST /payment/gateway/bank/pay.php HTTP/2.0", upstream: "fastcgi://unix:/run/php/php8.1-fpm-my_server.sock:", host: "my_server", referrer: "https://my_server/payment/gateway/bank/pay.php"
```
**2:**
```
2024/09/21 14:08:14 [error] 2300968#2300968: *642387 FastCGI sent in stderr: "PHP message: Default exception handler: Zapisi podataka za tablicu enrol_wallet_items nisu pronađeni. Debug: SELECT * FROM {enrol_wallet_items} WHERE id = ?
[array (
  0 => 17,
)]
Error code: invalidrecord
* line 1659 of /lib/dml/moodle_database.php: dml_missing_record_exception thrown
* line 1635 of /lib/dml/moodle_database.php: call to moodle_database->get_record_select()
* line 51 of /enrol/wallet/classes/payment/service_provider.php: call to moodle_database->get_record()
* line 7825 of /lib/moodlelib.php: call to enrol_wallet\payment\service_provider::get_payable()
* line 200 of /payment/classes/helper.php: call to component_class_callback()
* line 228 of /payment/classes/helper.php: call to core_payment\helper::get_payable()
* line 109 of /payment/gateway/bank/manage.php: call to core_payment\helper::get_gateway_configuration()" while reading upstream, client: 93.180.98.98, server: my_server, request: "GET /payment/gateway/bank/manage.php HTTP/2.0", upstream: "fastcgi://unix:/run/php/php8.1-fpm-my_server.sock:", host: "my_server"
```

**Solution:**

1. Modified manage.php to handle missing enrol_wallet_items records.
2. Updated the code to use information from the paygw_bank table when enrol_wallet_items data is unavailable.
3. Implemented a fallback mechanism to ensure correct amount display.


**Changes:**

**1. Handling missing records**

```
try {
    $config = (object) helper::get_gateway_configuration($bank_entry->component, $bank_entry->paymentarea, $bank_entry->itemid, 'bank');
    $payable = helper::get_payable($bank_entry->component, $bank_entry->paymentarea, $bank_entry->itemid);
    $currency = $payable->get_currency();
    $amount = helper::get_rounded_cost($payable->get_amount(), $currency, helper::get_gateway_surcharge('paypal'));
} catch (\Exception $e) {
    // Fallback to bank entry data if configuration or payable is unavailable
    $currency = $bank_entry->currency;
    $amount = $bank_entry->totalamount;
}
```

**2. Ensuring correct amount display**

1. Always use paygw_bank table data as the primary source for amount and currency.
2. Attempt to retrieve additional information and apply surcharges if available.
3. Fall back to original bank entry data if additional information retrieval fails.

**Testing:**

To test these changes, you should:

1. Create test payments using the bank gateway.
2. Manually delete some records from the enrol_wallet_items table (to speed up the process of removing temp data)
3. Access /payment/gateway/bank/manage.php and verify all pending payments are visible and manageable without errors.
4. Test payment processing for both scenarios: with and without existing enrol_wallet_items records.
5. Verify correct amount display for all pending payments.
6. Test approving and denying payments to ensure the process works correctly (it's expected that the user is signed up to a course or in case wallet top up, user should receive that amount)

These changes improve the reliability and accuracy of the payment management process when used with the moodle-enrol_wallet plugin.